### PR TITLE
Add a decorator to simplify creating an operator

### DIFF
--- a/examples/basic/add/run.py
+++ b/examples/basic/add/run.py
@@ -1,18 +1,9 @@
-import numpy as np
-
-from oremda import Client as OremdaClient
-from oremda import Operator as OremdaOperator
-
-class AddOperator(OremdaOperator):
-    def kernel(self, input_data, parameters):
-        value = parameters.get('value', 0)
-        output_data = input_data + value
-
-        return output_data
+from oremda.operator import operator
 
 
+@operator
+def add(data, params):
+    return data + params.get('value', 0)
 
-client = OremdaClient('/run/oremda/plasma.sock')
 
-operator = AddOperator('add', client)
-operator.start()
+add.start()

--- a/examples/basic/add/run.py
+++ b/examples/basic/add/run.py
@@ -4,6 +4,3 @@ from oremda.operator import operator
 @operator
 def add(data, params):
     return data + params.get('value', 0)
-
-
-add.start()

--- a/examples/basic/multiply/run.py
+++ b/examples/basic/multiply/run.py
@@ -4,6 +4,3 @@ from oremda.operator import operator
 @operator
 def multiply(data, params):
     return data * params.get('value', 1)
-
-
-multiply.start()

--- a/examples/basic/multiply/run.py
+++ b/examples/basic/multiply/run.py
@@ -1,16 +1,9 @@
-import numpy as np
+from oremda.operator import operator
 
-from oremda import Client as OremdaClient
-from oremda import Operator as OremdaOperator
 
-class MultiplyOperator(OremdaOperator):
-    def kernel(self, input_data, parameters):
-        value = parameters.get('value', 1)
-        output_data = input_data * value
+@operator
+def multiply(data, params):
+    return data * params.get('value', 1)
 
-        return output_data
 
-client = OremdaClient('/run/oremda/plasma.sock')
-
-operator = MultiplyOperator('multiply', client)
-operator.start()
+multiply.start()

--- a/examples/basic/viewer/run.py
+++ b/examples/basic/viewer/run.py
@@ -5,6 +5,3 @@ from oremda.operator import operator
 def view(data, params):
     print('VIEW DATA', data, flush=True)
     return data
-
-
-view.start()

--- a/examples/basic/viewer/run.py
+++ b/examples/basic/viewer/run.py
@@ -1,16 +1,10 @@
-import numpy as np
-
-from oremda import Client as OremdaClient
-from oremda import Operator as OremdaOperator
-
-class ViewOperator(OremdaOperator):
-    def kernel(self, input_data, parameters):
-        print("VIEW DATA", input_data, flush=True)
-
-        return input_data
+from oremda.operator import operator
 
 
-client = OremdaClient('/run/oremda/plasma.sock')
+@operator
+def view(data, params):
+    print('VIEW DATA', data, flush=True)
+    return data
 
-operator = ViewOperator('view', client)
-operator.start()
+
+view.start()

--- a/oremda/constants.py
+++ b/oremda/constants.py
@@ -1,1 +1,3 @@
+DEFAULT_PLASMA_SOCKET_PATH = '/run/oremda/plasma.sock'
+
 OREMDA_FINISHED_QUEUE = '/oremda_finished_queue'

--- a/oremda/operator.py
+++ b/oremda/operator.py
@@ -47,7 +47,7 @@ class Operator(ABC):
         pass
 
 
-def operator(func=None, name=None,
+def operator(func=None, name=None, start=True,
              plasma_socket_path=DEFAULT_PLASMA_SOCKET_PATH):
 
     # A decorator to automatically make an Operator where the function
@@ -64,7 +64,12 @@ def operator(func=None, name=None,
             return func(*args, **kwargs)
 
         OpClass = type(name, (Operator,), {'kernel': kernel})
-        return OpClass(name, Client(plasma_socket_path))
+        obj = OpClass(name, Client(plasma_socket_path))
+
+        if start:
+            obj.start()
+
+        return obj
 
     if func is not None:
         return decorator(func)

--- a/oremda/operator.py
+++ b/oremda/operator.py
@@ -63,7 +63,8 @@ def operator(func=None, name=None, start=True,
             # Remove self so the caller does not need to add it
             return func(*args, **kwargs)
 
-        OpClass = type(name, (Operator,), {'kernel': kernel})
+        class_name = f'{name.capitalize()}Operator'
+        OpClass = type(class_name, (Operator,), {'kernel': kernel})
         obj = OpClass(name, Client(plasma_socket_path))
 
         if start:


### PR DESCRIPTION
We can now just decorate a function, and it will do the work
of subclassing and setting the kernel function under the hood.

The name of the function is important, because the operator strings
in the pipeline will need to match.

The decorator actually returns an object of the subclass, rather
than the function.