### PR TITLE
Add script for converting json to Docker labels

### DIFF
--- a/oremda/clients/__init__.py
+++ b/oremda/clients/__init__.py
@@ -1,4 +1,4 @@
-from oremda.clients.odocker import DockerClient
+from oremda.clients.docker import DockerClient
 from oremda.clients.singularity import SingularityClient
 
 

--- a/oremda/clients/base/__init__.py
+++ b/oremda/clients/base/__init__.py
@@ -1,0 +1,9 @@
+from .client import ClientBase
+from .container import ContainerBase
+from .image import ImageBase
+
+__all__ = [
+    'ClientBase',
+    'ContainerBase',
+    'ImageBase',
+]

--- a/oremda/clients/base/client.py
+++ b/oremda/clients/base/client.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+
+
+class ClientBase(ABC):
+
+    @property
+    @abstractmethod
+    def client(self):
+        pass
+
+    @property
+    @abstractmethod
+    def type(self):
+        pass
+
+    @abstractmethod
+    def run(self):
+        pass

--- a/oremda/clients/base/client.py
+++ b/oremda/clients/base/client.py
@@ -14,5 +14,9 @@ class ClientBase(ABC):
         pass
 
     @abstractmethod
+    def image(self):
+        pass
+
+    @abstractmethod
     def run(self):
         pass

--- a/oremda/clients/base/container.py
+++ b/oremda/clients/base/container.py
@@ -1,23 +1,6 @@
 from abc import ABC, abstractmethod
 
 
-class ClientBase(ABC):
-
-    @property
-    @abstractmethod
-    def client(self):
-        pass
-
-    @property
-    @abstractmethod
-    def type(self):
-        pass
-
-    @abstractmethod
-    def run(self):
-        pass
-
-
 class ContainerBase(ABC):
 
     @property

--- a/oremda/clients/base/image.py
+++ b/oremda/clients/base/image.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+
+from oremda.clients.utils import flat_get_item, flat_to_nested
+
+
+class ImageBase(ABC):
+
+    @property
+    @abstractmethod
+    def labels(self):
+        pass
+
+    @property
+    def oremda_labels(self):
+        oremda_labels = flat_get_item(self.labels, 'oremda')
+        return flat_to_nested(oremda_labels)

--- a/oremda/clients/docker/__init__.py
+++ b/oremda/clients/docker/__init__.py
@@ -1,0 +1,9 @@
+from .client import DockerClient
+from .container import DockerContainer
+from .image import DockerImage
+
+__all__ = [
+    'DockerClient',
+    'DockerContainer',
+    'DockerImage',
+]

--- a/oremda/clients/docker/client.py
+++ b/oremda/clients/docker/client.py
@@ -1,0 +1,26 @@
+import docker
+
+from oremda.clients.base import ClientBase
+from oremda.clients.docker.container import DockerContainer
+from oremda.clients.docker.image import DockerImage
+
+
+class DockerClient(ClientBase):
+    @property
+    def client(self):
+        return docker.from_env()
+
+    @property
+    def type(self):
+        return 'docker'
+
+    def image(self, name):
+        return DockerImage(self.client, name)
+
+    def run(self, *args, **kwargs):
+        # Always run in detached mode
+        kwargs = kwargs.copy()
+        kwargs['detach'] = True
+
+        container = self.client.containers.run(*args, **kwargs)
+        return DockerContainer(container)

--- a/oremda/clients/docker/container.py
+++ b/oremda/clients/docker/container.py
@@ -1,24 +1,4 @@
-import docker
-
-from oremda.clients.base import ClientBase, ContainerBase
-
-
-class DockerClient(ClientBase):
-    @property
-    def client(self):
-        return docker.from_env()
-
-    @property
-    def type(self):
-        return 'docker'
-
-    def run(self, *args, **kwargs):
-        # Always run in detached mode
-        kwargs = kwargs.copy()
-        kwargs['detach'] = True
-
-        container = self.client.containers.run(*args, **kwargs)
-        return DockerContainer(container)
+from oremda.clients.base import ContainerBase
 
 
 class DockerContainer(ContainerBase):

--- a/oremda/clients/docker/image.py
+++ b/oremda/clients/docker/image.py
@@ -1,0 +1,11 @@
+from oremda.clients.base import ImageBase
+
+
+class DockerImage(ImageBase):
+    def __init__(self, client, name):
+        self.client = client
+        self.image = client.images.get(name)
+
+    @property
+    def labels(self):
+        return self.image.labels

--- a/oremda/clients/singularity/__init__.py
+++ b/oremda/clients/singularity/__init__.py
@@ -1,0 +1,9 @@
+from .client import SingularityClient
+from .container import SingularityContainer
+from .image import SingularityImage
+
+__all__ = [
+    'SingularityClient',
+    'SingularityContainer',
+    'SingularityImage',
+]

--- a/oremda/clients/singularity/client.py
+++ b/oremda/clients/singularity/client.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from spython.main import Client as client
+
+from oremda.clients.base import ClientBase
+from oremda.clients.singularity.container import SingularityContainer
+from oremda.clients.singularity.image import SingularityImage
+
+
+class SingularityClient(ClientBase):
+
+    @property
+    def client(self):
+        return client
+
+    @property
+    def type(self):
+        return 'singularity'
+
+    def image(self, path):
+        return SingularityImage(self.client, path)
+
+    def run(self, image, *args, **kwargs):
+        kwargs = self._docker_kwargs_to_singularity(kwargs)
+
+        name = Path(image).stem
+        container = SingularityContainer(image, name)
+        container.run(*args, **kwargs)
+
+        return container
+
+    def _docker_kwargs_to_singularity(self, kwargs):
+        # This converts docker-style kwargs to singularity
+        ret = {}
+        options = []
+        if kwargs.get('detach', False) is False:
+            msg = 'Detach mode is currently required for singularity'
+            raise Exception(msg)
+
+        if 'ipc_mode' in kwargs:
+            print('Warning: IPC mode will be ignored for singularity')
+
+        if 'volumes' in kwargs:
+            volumes = kwargs['volumes']
+            for key, val in volumes.items():
+                bind = val['bind']
+                options += ['--bind', f'{key}:{bind}']
+
+        ret['options'] = options
+        return ret

--- a/oremda/clients/singularity/container.py
+++ b/oremda/clients/singularity/container.py
@@ -1,50 +1,9 @@
-from pathlib import Path
 from threading import Lock
 
 from spython.main import Client as client
 
 from oremda.utils.concurrency import ThreadPoolSingleton
-from oremda.clients.base import ClientBase, ContainerBase
-
-
-class SingularityClient(ClientBase):
-
-    @property
-    def client(self):
-        return client
-
-    @property
-    def type(self):
-        return 'singularity'
-
-    def run(self, image, *args, **kwargs):
-        kwargs = self._docker_kwargs_to_singularity(kwargs)
-
-        name = Path(image).stem
-        container = SingularityContainer(image, name)
-        container.run(*args, **kwargs)
-
-        return container
-
-    def _docker_kwargs_to_singularity(self, kwargs):
-        # This converts docker-style kwargs to singularity
-        ret = {}
-        options = []
-        if kwargs.get('detach', False) is False:
-            msg = 'Detach mode is currently required for singularity'
-            raise Exception(msg)
-
-        if 'ipc_mode' in kwargs:
-            print('Warning: IPC mode will be ignored for singularity')
-
-        if 'volumes' in kwargs:
-            volumes = kwargs['volumes']
-            for key, val in volumes.items():
-                bind = val['bind']
-                options += ['--bind', f'{key}:{bind}']
-
-        ret['options'] = options
-        return ret
+from oremda.clients.base import ContainerBase
 
 
 class SingularityContainer(ContainerBase):

--- a/oremda/clients/singularity/image.py
+++ b/oremda/clients/singularity/image.py
@@ -1,0 +1,19 @@
+from oremda.clients.base import ImageBase
+
+
+class SingularityImage(ImageBase):
+    def __init__(self, client, path):
+        self.client = client
+        self.path = path
+
+    @property
+    def labels(self):
+        out = self.client.inspect(self.path)
+        if 'attributes' not in out:
+            raise Exception(f'Failed to get attributes: {out}')
+
+        attributes = out['attributes']
+        if 'labels' not in attributes:
+            raise Exception(f'Failed to get labels: {attributes}')
+
+        return attributes['labels']

--- a/oremda/clients/utils.py
+++ b/oremda/clients/utils.py
@@ -32,3 +32,45 @@ def run_containers(client, names, args_list, kwargs_list):
             for container in containers:
                 print(f'{container.id}: {container.logs()}')
             raise
+
+
+def nested_to_flat(nested, delimiter='.'):
+    path = ''
+    flat = {}
+
+    def recurse(cur):
+        nonlocal path
+        parent = path
+        for key, value in cur.items():
+            path = delimiter.join([parent, key]) if parent else key
+            if isinstance(value, dict):
+                recurse(value)
+            else:
+                flat[path] = str(value)
+
+        path = parent
+
+    recurse(nested)
+    return flat
+
+
+def flat_to_nested(flat, delimiter='.'):
+    nested = {}
+    for full_key, value in flat.items():
+        keys = full_key.split(delimiter)
+        cur = nested
+        for key in keys[:-1]:
+            cur = cur.setdefault(key, {})
+
+        cur[keys[-1]] = value
+
+    return nested
+
+
+def flat_get_item(flat, item, delimiter='.'):
+    prefix = f'{item}{delimiter}'
+    keys = [x[len(prefix):] for x in flat.keys() if x.startswith(prefix)]
+    if not keys:
+        raise KeyError(item)
+
+    return {key: flat[f'{prefix}{key}'] for key in keys}

--- a/oremda/clients/utils.py
+++ b/oremda/clients/utils.py
@@ -69,8 +69,8 @@ def flat_to_nested(flat, delimiter='.'):
 
 def flat_get_item(flat, item, delimiter='.'):
     prefix = f'{item}{delimiter}'
-    keys = [x[len(prefix):] for x in flat.keys() if x.startswith(prefix)]
+    keys = [x for x in flat.keys() if x.startswith(prefix)]
     if not keys:
         raise KeyError(item)
 
-    return {key: flat[f'{prefix}{key}'] for key in keys}
+    return {key[len(prefix):]: flat[key] for key in keys}

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:20.04
+
+LABEL oremda.type=add \
+  oremda.ports.input.scalars.type=data \
+  oremda.ports.input.meta.type=meta \
+  oremda.ports.output.scalars.type=data \
+  oremda.ports.output.meta.type=meta \
+  oremda.params.foo.type=number \
+  oremda.params.foo.required=True \
+  oremda.params.foo.default=0

--- a/scripts/docker/example_description.json
+++ b/scripts/docker/example_description.json
@@ -17,5 +17,12 @@
                 "type": "meta"
             }
         }
+    },
+    "params": {
+        "foo": {
+            "type": "number",
+            "required": true,
+            "default": 0
+        }
     }
 }

--- a/scripts/docker/example_description.json
+++ b/scripts/docker/example_description.json
@@ -1,0 +1,21 @@
+{
+    "type": "add",
+    "ports": {
+        "input": {
+            "scalars": {
+                "type": "data"
+            },
+            "meta": {
+                "type": "meta"
+            }
+        },
+        "output": {
+            "scalars": {
+                "type": "data"
+            },
+            "meta": {
+                "type": "meta"
+            }
+        }
+    }
+}

--- a/scripts/docker/example_description.json
+++ b/scripts/docker/example_description.json
@@ -1,28 +1,30 @@
 {
-    "type": "add",
-    "ports": {
-        "input": {
-            "scalars": {
-                "type": "data"
+    "oremda": {
+        "type": "add",
+        "ports": {
+            "input": {
+                "scalars": {
+                    "type": "data"
+                },
+                "meta": {
+                    "type": "meta"
+                }
             },
-            "meta": {
-                "type": "meta"
+            "output": {
+                "scalars": {
+                    "type": "data"
+                },
+                "meta": {
+                    "type": "meta"
+                }
             }
         },
-        "output": {
-            "scalars": {
-                "type": "data"
-            },
-            "meta": {
-                "type": "meta"
+        "params": {
+            "foo": {
+                "type": "number",
+                "required": true,
+                "default": 0
             }
-        }
-    },
-    "params": {
-        "foo": {
-            "type": "number",
-            "required": true,
-            "default": 0
         }
     }
 }

--- a/scripts/docker/json_to_docker_labels.py
+++ b/scripts/docker/json_to_docker_labels.py
@@ -1,25 +1,6 @@
 #!/usr/bin/env python3
 
-
-def dict_to_docker_labels(d, delimiter='.'):
-
-    path = ''
-    labels = {}
-
-    def recurse(cur):
-        nonlocal path
-        parent = path
-        for key, value in cur.items():
-            path = delimiter.join([parent, key]) if parent else key
-            if isinstance(value, dict):
-                recurse(value)
-            else:
-                labels[path] = str(value)
-
-        path = parent
-
-    recurse(d)
-    return labels
+from oremda.clients.utils import nested_to_flat
 
 
 if __name__ == '__main__':
@@ -33,7 +14,12 @@ if __name__ == '__main__':
     with open(sys.argv[1], 'r') as rf:
         d = json.load(rf)
 
-    labels = dict_to_docker_labels(d)
+    labels = nested_to_flat(d)
 
+    ending = '\\\n  '
+    output = 'LABEL '
     for key, value in labels.items():
-        print(f'LABEL {key}={value}')
+        output += f'{key}={value} {ending}'
+
+    output = output[:-len(ending)]
+    print(output)

--- a/scripts/docker/json_to_docker_labels.py
+++ b/scripts/docker/json_to_docker_labels.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+
+def dict_to_docker_labels(d, delimiter='.'):
+
+    path = ''
+    labels = {}
+
+    def recurse(cur):
+        nonlocal path
+        parent = path
+        for key, value in cur.items():
+            path = delimiter.join([parent, key]) if parent else key
+            if isinstance(value, dict):
+                recurse(value)
+            else:
+                labels[path] = str(value)
+
+        path = parent
+
+    recurse(d)
+    return labels
+
+
+if __name__ == '__main__':
+
+    import json
+    import sys
+
+    if len(sys.argv) < 2:
+        sys.exit('usage: <script> <json_file>')
+
+    with open(sys.argv[1], 'r') as rf:
+        d = json.load(rf)
+
+    labels = dict_to_docker_labels(d)
+
+    for key, value in labels.items():
+        print(f'LABEL {key}={value}')

--- a/scripts/singularity/docker_to_singularity.py
+++ b/scripts/singularity/docker_to_singularity.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+"""docker_to_singularity.py
+
+This script will create a singularity image from a docker image,
+and transfer the docker labels over to the singularity image.
+
+This script will no longer be needed if this issue is resolved:
+https://github.com/sylabs/singularity/issues/146
+"""
+
+import os
+import re
+import tempfile
+import sys
+
+import docker
+from spython.main import Client as sclient
+
+if len(sys.argv) < 2:
+    sys.exit('Usage: <script> <docker_image>')
+
+dclient = docker.from_env()
+image_name = sys.argv[1]
+
+image = dclient.images.get(image_name)
+labels = image.labels
+
+labels_string = ''
+for key, value in labels.items():
+    labels_string += f'    {key} {value}\n'
+
+definition = f"""\
+Bootstrap: docker-daemon
+From: {image.id}
+
+%labels
+{labels_string}
+"""
+
+output_name = re.sub('[:/]', '_', f'{image_name}.simg')
+
+tf = tempfile.NamedTemporaryFile('w', delete=False)
+try:
+    tf.close()
+    with open(tf.name, 'w') as wf:
+        wf.write(definition)
+
+    sclient.build(tf.name, image=output_name, sudo=True)
+finally:
+    os.unlink(tf.name)
+    del tf


### PR DESCRIPTION
The Docker labels will be used for descriptions in the operators.

This script allows us to write the descriptions in a json format
and then automatically convert it to the Docker label format for
the Docker images.