### PR TITLE
Add a basic stateful volume rendering example

### DIFF
--- a/examples/operators/stateful_volume_renderer/Dockerfile
+++ b/examples/operators/stateful_volume_renderer/Dockerfile
@@ -1,0 +1,24 @@
+FROM oremda/oremda
+
+# libgl1-mesa-glx is required for VTK
+# xvfb is required to make a virtual frame buffer for rendering
+RUN apt-get update && \
+    apt-get install -y \
+      libgl1-mesa-glx \
+      xvfb && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install vtk
+
+COPY run.py /
+
+LABEL oremda.name="stateful_volume_renderer" \
+      oremda.ports.input.data.type="data" \
+      oremda.params.filename.type="string" \
+      oremda.params.filename.required="true" \
+      oremda.params.clear.type="bool" \
+      oremda.params.clear.required="false"
+
+ENV PYTHONUNBUFFERED=1
+
+ENTRYPOINT ["python", "/run.py"]

--- a/examples/operators/stateful_volume_renderer/build.sh
+++ b/examples/operators/stateful_volume_renderer/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+script_dir=$(dirname "$0")
+
+docker build -t oremda/stateful_volume_renderer $script_dir

--- a/examples/operators/stateful_volume_renderer/run.py
+++ b/examples/operators/stateful_volume_renderer/run.py
@@ -1,0 +1,163 @@
+import os
+from pathlib import Path
+import subprocess
+
+import numpy as np
+
+import vtk
+
+from vtk.util.numpy_support import numpy_to_vtk
+
+from oremda import operator
+
+ren_win = vtk.vtkRenderWindow()
+ren_win.OffScreenRenderingOn()
+
+ren = vtk.vtkRenderer()
+ren_win.AddRenderer(ren)
+
+iren = vtk.vtkRenderWindowInteractor()
+iren.SetRenderWindow(ren_win)
+style = vtk.vtkInteractorStyleTrackballCamera()
+iren.SetInteractorStyle(style)
+
+ren_win.SetSize(800, 600)
+ren_win.SetWindowName('Volumes')
+
+
+def activate_virtual_framebuffer():
+    '''
+    Activates a virtual (headless) framebuffer for rendering 3D
+    scenes via VTK.
+
+    Most critically, this function is useful when this code is being run
+    in a Dockerized notebook, or over a server without X forwarding.
+
+    * Requires the following packages:
+      * `sudo apt-get install libgl1-mesa-dev xvfb`
+    '''
+
+    os.environ['DISPLAY'] = ':99.0'
+
+    commands = ['Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &',
+                'sleep 3']
+
+    for command in commands:
+        subprocess.call(command, shell=True)
+
+
+# This is necessary for any kind of rendering in the container
+activate_virtual_framebuffer()
+
+
+def array_to_image_data(arr):
+    if arr.ndim == 2:
+        arr = arr[..., np.newaxis]
+
+    image_data = vtk.vtkImageData()
+    image_data.SetDimensions(*arr.shape)
+
+    pd = image_data.GetPointData()
+    pd.SetScalars(numpy_to_vtk(arr.ravel()))
+
+    return image_data
+
+
+def create_color_function(arr, points=None, data_range=None):
+    if points is None:
+        points = [
+            (0, 0, 0),
+            (1, 0, 0),
+            (0, 1, 0),
+            (0, 0, 1),
+        ]
+
+    if data_range is not None:
+        amin, amax = data_range
+    else:
+        amin, amax = np.nanmin(arr), np.nanmax(arr)
+
+    steps = np.linspace(amin, amax, len(points))
+
+    color_function = vtk.vtkColorTransferFunction()
+    for step, point in zip(steps, points):
+        color_function.AddRGBPoint(step, *point)
+
+    return color_function
+
+
+def create_opacity_function(arr, values=None, data_range=None):
+    if values is None:
+        values = [
+            0.0,
+            0.1,
+            0.7,
+            1.0,
+        ]
+
+    if data_range is not None:
+        amin, amax = data_range
+    else:
+        amin, amax = np.nanmin(arr), np.nanmax(arr)
+
+    steps = np.linspace(amin, amax, len(values))
+
+    opacity_function = vtk.vtkPiecewiseFunction()
+    for step, value in zip(steps, values):
+        opacity_function.AddPoint(step, value)
+
+    return opacity_function
+
+
+def add_volume(arr):
+    image_data = array_to_image_data(arr)
+
+    producer = vtk.vtkTrivialProducer()
+    producer.SetOutput(image_data)
+
+    color = create_color_function(arr)
+    opacity = create_opacity_function(arr)
+
+    volume = vtk.vtkVolume()
+    mapper = vtk.vtkGPUVolumeRayCastMapper()
+    prop = vtk.vtkVolumeProperty()
+
+    prop.SetColor(color)
+    prop.SetScalarOpacity(opacity)
+    mapper.SetInputConnection(producer.GetOutputPort())
+    mapper.SetMaskTypeToBinary()
+
+    volume.SetMapper(mapper)
+    volume.SetProperty(prop)
+
+    ren.AddViewProp(volume)
+
+
+def write_window(ren_win, filename):
+    w2i_filter = vtk.vtkWindowToImageFilter()
+    writer = vtk.vtkPNGWriter()
+
+    w2i_filter.SetInput(ren_win)
+    writer.SetInputConnection(w2i_filter.GetOutputPort())
+    writer.SetFileName(str(filename))
+    writer.Write()
+
+
+@operator
+def stateful_volume_renderer(meta, data, parameters):
+    filename = parameters.get('filename', '')
+    clear = parameters.get('clear', False)
+
+    filepath = Path('/data') / filename
+
+    if clear:
+        ren.RemoveAllViewProps()
+
+    add_volume(data['data'])
+
+    ren.ResetCamera()
+    ren_win.Render()
+
+    write_window(ren_win, filepath)
+
+    return meta, {}

--- a/examples/operators/vtk_reader/Dockerfile
+++ b/examples/operators/vtk_reader/Dockerfile
@@ -1,0 +1,18 @@
+FROM oremda/oremda
+
+# libgl1-mesa-glx is required for VTK
+RUN apt-get update && \
+    apt-get install -y \
+      libgl1-mesa-glx && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install vtk
+
+COPY run.py /
+
+LABEL oremda.name="vtk_reader" \
+      oremda.ports.output.data.type="data" \
+      oremda.params.filename.type="string" \
+      oremda.params.filename.required="true"
+
+ENTRYPOINT ["python", "/run.py"]

--- a/examples/operators/vtk_reader/build.sh
+++ b/examples/operators/vtk_reader/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+script_dir=$(dirname "$0")
+
+docker build -t oremda/vtk_reader $script_dir

--- a/examples/operators/vtk_reader/run.py
+++ b/examples/operators/vtk_reader/run.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import numpy as np
+
+import vtk
+from vtk.numpy_interface import dataset_adapter as dsa
+
+from oremda import operator
+
+
+READERS = {
+    'vtk': vtk.vtkStructuredPointsReader,
+    'vti': vtk.vtkXMLImageDataReader,
+}
+
+
+def read_file(file_name):
+    ext = Path(file_name).suffix[1:]
+    if ext not in READERS:
+        raise Exception(f'Unknown extension: {ext}')
+
+    reader = READERS[ext]()
+    reader.SetFileName(str(file_name))
+    reader.Update()
+    return reader.GetOutput()
+
+
+def to_numpy_array(data_object, key=None):
+    wrapped = dsa.WrapDataObject(data_object)
+    pd = wrapped.PointData
+
+    if key is None:
+        # Grab the first key we can find
+        key = next(iter(pd.keys()))
+
+    vtk_array = pd[key].reshape(data_object.GetDimensions())
+    return np.array(vtk_array)
+
+
+@operator
+def vtk_reader(meta, data, parameters):
+    filename = parameters.get('filename', '')
+    filepath = Path('/data') / filename
+
+    data = read_file(filepath)
+
+    output = {
+        'data': to_numpy_array(data)
+    }
+
+    return meta, output

--- a/examples/volume_renderer/build.sh
+++ b/examples/volume_renderer/build.sh
@@ -7,12 +7,7 @@ build_singularity=false
 prefix=""
 
 directories=(
-  background_fit
-  ncem_reader
-  plot
-  stateful_volume_renderer
-  subtract
-  vtk_reader
+  volume_renderer_runner
 )
 
 script_dir=$(dirname "$0")
@@ -26,7 +21,7 @@ $root_dir/docker/oremda/build.sh
 # Next, build all the example directories
 for name in "${directories[@]}"
 do
-  bash $script_dir/$name/build.sh
+  docker build -t oremda/$prefix$name -f $script_dir/$name/Dockerfile $script_dir/$name
 done
 
 if [ "$build_singularity" != true ]; then
@@ -37,3 +32,4 @@ singularity_dir=$script_dir/.singularity
 for name in "${directories[@]}"
 do
   singularity build --force $singularity_dir/$prefix$name.simg docker-daemon://oremda/$prefix$name:latest
+done

--- a/examples/volume_renderer/run.sh
+++ b/examples/volume_renderer/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+OREMDA_VAR_DIR=/run/oremda
+DATA_DIR=/home/patrick/virtualenvs/oremda/data
+DOCKER_SOCKET=/var/run/docker.sock
+
+docker run \
+  --shm-size=750m \
+  -v $OREMDA_VAR_DIR:$OREMDA_VAR_DIR \
+  -v $DATA_DIR:/data \
+  -v $DOCKER_SOCKET:$DOCKER_SOCKET \
+  --ipc=shareable \
+  oremda/volume_renderer_runner

--- a/examples/volume_renderer/volume_renderer_runner/Dockerfile
+++ b/examples/volume_renderer/volume_renderer_runner/Dockerfile
@@ -1,0 +1,13 @@
+FROM oremda/oremda
+
+RUN pip install \
+  six
+
+COPY run.py /
+COPY pipeline.json /
+
+# Since we leave this image open until the end, make sure all
+# output gets printed as it comes in.
+ENV PYTHONUNBUFFERED=1
+
+ENTRYPOINT ["python", "/run.py"]

--- a/examples/volume_renderer/volume_renderer_runner/pipeline.json
+++ b/examples/volume_renderer/volume_renderer_runner/pipeline.json
@@ -1,0 +1,57 @@
+{
+  "nodes": [
+    {
+      "id": "10",
+      "image": "oremda/vtk_reader",
+      "params": {
+          "filename": "recon.vti"
+      }
+    },
+    {
+      "id": "11",
+      "image": "oremda/vtk_reader",
+      "params": {
+          "filename": "nanoparticle.vti"
+      }
+    },
+    {
+      "id": "12",
+      "image": "oremda/stateful_volume_renderer",
+      "params": {
+          "filename": "only_recon.png"
+      }
+    },
+    {
+      "id": "13",
+      "image": "oremda/stateful_volume_renderer",
+      "params": {
+          "filename": "only_nano.png",
+          "clear": true
+      }
+    },
+    {
+      "id": "14",
+      "image": "oremda/stateful_volume_renderer",
+      "params": {
+          "filename": "both.png"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "type": "data",
+      "from": { "id": "10", "port": "data" },
+      "to": { "id": "12", "port": "data" }
+    },
+    {
+      "type": "data",
+      "from": { "id": "11", "port": "data" },
+      "to": { "id": "13", "port": "data" }
+    },
+    {
+      "type": "data",
+      "from": { "id": "10", "port": "data" },
+      "to": { "id": "14", "port": "data" }
+    }
+  ]
+}

--- a/examples/volume_renderer/volume_renderer_runner/run.py
+++ b/examples/volume_renderer/volume_renderer_runner/run.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+import json
+
+from oremda.clients import Client as ContainerClient
+from oremda.shared_resources import Client as MemoryClient
+from oremda.registry import Registry
+from oremda.constants import DEFAULT_PLASMA_SOCKET_PATH, DEFAULT_DATA_DIR
+from oremda.utils.plasma import start_plasma_store
+import oremda.pipeline
+
+plasma_kwargs = {
+    'memory': 500_000_000,
+    'socket_path': DEFAULT_PLASMA_SOCKET_PATH,
+}
+
+with start_plasma_store(**plasma_kwargs):
+    memory_client = MemoryClient(DEFAULT_PLASMA_SOCKET_PATH)
+    container_client = ContainerClient('docker')
+
+    registry = Registry(memory_client, container_client)
+
+    self_container = container_client.self_container()
+
+    run_kwargs = {
+        'volumes': {mount.source: {'bind': mount.destination} for mount in self_container.mounts},
+        'ipc_mode': f"container:{self_container.id}",
+        'detach': True,
+        'working_dir': DEFAULT_DATA_DIR,
+    }
+
+    registry.run_kwargs = run_kwargs
+
+    with open('/pipeline.json') as f:
+        pipeline_obj = json.load(f)
+
+    pipeline = oremda.pipeline.deserialize_pipeline(pipeline_obj, memory_client, registry)
+    pipeline.run()
+
+    registry.release()


### PR DESCRIPTION
This adds a vtk reader operator, and a stateful volume rendering
operator.

The stateful volume rendering operator is our first example of an
operator that has state. Running this operator will add a volume to
the operator's internal `vtkRenderWindow`. Currently, the operator will
just write out a PNG file of what it rendered last.

No metadata such as spacing and origin is currently being considered.

An example is attached, along with the output.

[recon.vti.zip](https://github.com/OpenChemistry/oremda/files/6863687/recon.vti.zip)
[nanoparticle.vti.zip](https://github.com/OpenChemistry/oremda/files/6863690/nanoparticle.vti.zip)

![only_nano](https://user-images.githubusercontent.com/9558430/126671077-bd40942b-d8cb-44fb-b08c-56b1499ec5ff.png)
![only_recon](https://user-images.githubusercontent.com/9558430/126671090-ad5608dc-62f2-4199-8fc6-04468e8d0a29.png)
![both](https://user-images.githubusercontent.com/9558430/126671095-da6c5351-e3a2-4bc8-a35e-8e548d598328.png)