### PR TITLE
Convert oremda label values to native types

### DIFF
--- a/oremda/clients/__init__.py
+++ b/oremda/clients/__init__.py
@@ -25,9 +25,8 @@ def client_from_image(image_path: Union[str, PurePath]) -> ClientBase:
     # Try to automatically determine the type of client based upon
     # the image provided, and return it.
 
-    if ':' in image_path or not Path(image_path).exists():
-        # If it contains a colon, or the file path does not exist,
-        # assume it is docker.
+    if not Path(image_path).exists():
+        # If the file path does not exist, assume it is docker.
         return Client('docker')
 
     return Client('singularity')

--- a/oremda/clients/__init__.py
+++ b/oremda/clients/__init__.py
@@ -1,3 +1,4 @@
+from pathlib import Path, PurePath
 from typing import Union
 
 from oremda.clients.base.client import ClientBase
@@ -18,3 +19,15 @@ def Client(type: Union[ContainerType, str] = ContainerType.Docker) -> ClientBase
         raise Exception(f'Unknown container type: {type}')
 
     return container_types[type]()
+
+
+def client_from_image(image_path: Union[str, PurePath]) -> ClientBase:
+    # Try to automatically determine the type of client based upon
+    # the image provided, and return it.
+
+    if ':' in image_path or not Path(image_path).exists():
+        # If it contains a colon, or the file path does not exist,
+        # assume it is docker.
+        return Client('docker')
+
+    return Client('singularity')

--- a/oremda/clients/base/image.py
+++ b/oremda/clients/base/image.py
@@ -7,10 +7,10 @@ class ImageBase(ABC):
 
     @property
     @abstractmethod
-    def labels(self):
+    def raw_labels(self):
         pass
 
     @property
-    def oremda_labels(self):
-        oremda_labels = flat_get_item(self.labels, 'oremda')
-        return flat_to_nested(oremda_labels)
+    def labels(self):
+        labels = flat_get_item(self.raw_labels, 'oremda')
+        return flat_to_nested(labels)

--- a/oremda/clients/base/image.py
+++ b/oremda/clients/base/image.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
 
+from pydantic.error_wrappers import ValidationError
+
 from oremda.clients.utils import flat_get_item, flat_to_nested
+from oremda.typing import OperatorLabels
 
 
 class ImageBase(ABC):
@@ -11,6 +14,13 @@ class ImageBase(ABC):
         pass
 
     @property
-    def labels(self):
+    def labels(self) -> OperatorLabels:
         labels = flat_get_item(self.raw_labels, 'oremda')
-        return flat_to_nested(labels)
+        return OperatorLabels(**flat_to_nested(labels))
+
+    def validate_labels(self):
+        try:
+            self.labels
+        except ValidationError as e:
+            msg = f'Required labels are missing under the oremda prefix:\n{e}'
+            raise Exception(msg) from None

--- a/oremda/clients/docker/image.py
+++ b/oremda/clients/docker/image.py
@@ -7,5 +7,5 @@ class DockerImage(ImageBase):
         self.image = client.images.get(name)
 
     @property
-    def labels(self):
+    def raw_labels(self):
         return self.image.labels

--- a/oremda/clients/singularity/image.py
+++ b/oremda/clients/singularity/image.py
@@ -7,7 +7,7 @@ class SingularityImage(ImageBase):
         self.path = path
 
     @property
-    def labels(self):
+    def raw_labels(self):
         out = self.client.inspect(self.path)
         if 'attributes' not in out:
             raise Exception(f'Failed to get attributes: {out}')

--- a/oremda/registry.py
+++ b/oremda/registry.py
@@ -27,18 +27,7 @@ class Registry:
 
     def _inspect(self, image_name: str):
         image: Any = self.container_client.image(image_name)
-
-        labels = image.labels
-
-        ports = labels.setdefault('ports', {})
-        ports.setdefault('input', {})
-        ports.setdefault('output', {})
-
-        name = labels.get('name')
-
-        assert(name is not None)
-
-        return labels
+        return image.labels
 
     def _info(self, image_name: str):
         info = self.images.get(image_name)
@@ -46,19 +35,19 @@ class Registry:
             labels = self._inspect(image_name)
 
             info = ImageInfo(**{
-                'name': labels['name'],
+                'name': labels.name,
                 'inputs': {
                     name: PortInfo(**{
                         'name': name,
-                        'type': value['type']
-                    }) for name, value in labels['ports']['input'].items()
+                        'type': value.type
+                    }) for name, value in labels.ports.input.items()
                 },
                 'outputs': {
                     name: PortInfo(**{
-                        'name': name, 'type': value['type']
-                    }) for name, value in labels['ports']['output'].items()
+                        'name': name, 'type': value.type
+                    }) for name, value in labels.ports.output.items()
                 },
-                'params': labels['params']
+                'params': {k: v.dict() for k, v in labels.params.items()}
             })
             self.images[image_name] = info
 

--- a/oremda/registry.py
+++ b/oremda/registry.py
@@ -28,7 +28,7 @@ class Registry:
     def _inspect(self, image_name: str):
         image: Any = self.container_client.image(image_name)
 
-        labels = image.oremda_labels
+        labels = image.labels
 
         ports = labels.setdefault('ports', {})
         ports.setdefault('input', {})

--- a/oremda/typing/__init__.py
+++ b/oremda/typing/__init__.py
@@ -7,6 +7,7 @@ from enum import Enum
 
 IdType = Union[str, UUID]
 PortKey = str
+ParamKey = str
 JSONType = Dict[str, Any]
 DataType = np.ndarray
 MetaType = JSONType
@@ -87,3 +88,20 @@ class PipelineJSON(BaseModel):
     id: Optional[IdType] = None
     nodes: Sequence[NodeJSON] = []
     edges: Sequence[EdgeJSON] = []
+
+class PortLabels(BaseModel):
+    type: PortType = PortType.Data
+    required: bool = True
+
+class PortsLabels(BaseModel):
+    input: Dict[PortKey, PortLabels] = {}
+    output: Dict[PortKey, PortLabels] = {}
+
+class ParamLabels(BaseModel):
+    type: str
+    required: bool = True
+
+class OperatorLabels(BaseModel):
+    name: str
+    ports: PortsLabels
+    params: Dict[ParamKey, ParamLabels] = {}

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-LABEL oremda.type=add \
+LABEL oremda.name=add \
   oremda.ports.input.scalars.type=data \
   oremda.ports.input.meta.type=meta \
   oremda.ports.output.scalars.type=data \

--- a/scripts/validation/validate_labels.py
+++ b/scripts/validation/validate_labels.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+import sys
+
+from oremda.clients import client_from_image
+
+
+if len(sys.argv) < 2:
+    sys.exit('Usage: <script> <image>')
+
+image_path = sys.argv[1]
+client = client_from_image(image_path)
+
+image = client.image(image_path)
+image.validate_labels()
+print('Labels are valid!')


### PR DESCRIPTION
This allows us to avoid converting their types later while we are
reading the label values.

We can wait to merge this until #18 is merged since there will likely be some small conflicts.