### PR TITLE
Split up MPI implementations for thread support

### DIFF
--- a/examples/mpi/operator_config.json
+++ b/examples/mpi/operator_config.json
@@ -1,5 +1,5 @@
 {
-  "oremda/ncem_reader": {
+  "oremda/ncem_reader_eels": {
     "run_locations": [1, 7]
   },
   "oremda/background_fit": {

--- a/examples/mpi/pipeline.json
+++ b/examples/mpi/pipeline.json
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "id": "10",
-      "image": "oremda/ncem_reader",
+      "image": "oremda/ncem_reader_eels",
       "params": {
           "filename": "08_carbon.dm3"
       }

--- a/examples/mpi/run.sh
+++ b/examples/mpi/run.sh
@@ -2,7 +2,7 @@
 #SBATCH --account=ncemhub
 #SBATCH --qos=debug
 #SBATCH -C haswell
-#SBATCH --time=00:02:00
+#SBATCH --time=00:01:00
 #SBATCH -N 8
 
 home=/global/homes/p/psavery/

--- a/oremda/messengers/mpi/implementations/__init__.py
+++ b/oremda/messengers/mpi/implementations/__init__.py
@@ -1,0 +1,14 @@
+from oremda.utils.mpi import mpi_thread_support
+
+from .thread_multiple import MPIThreadMultipleImplementation
+from .thread_serial import MPIThreadSerialImplementation
+
+implementations = {
+    "MPI_THREAD_SERIALIZED": MPIThreadSerialImplementation,
+    "MPI_THREAD_MULTIPLE": MPIThreadMultipleImplementation,
+}
+
+if mpi_thread_support not in implementations:
+    raise NotImplementedError(mpi_thread_support)
+
+MPIMessengerImplementation = implementations[mpi_thread_support]  # type: ignore

--- a/oremda/messengers/mpi/implementations/thread_multiple.py
+++ b/oremda/messengers/mpi/implementations/thread_multiple.py
@@ -1,0 +1,22 @@
+from mpi4py import MPI
+
+from oremda.utils.singleton import Singleton
+
+comm = MPI.COMM_WORLD
+
+
+class MPIThreadMultipleImplementation(Singleton):
+    """This class just sends and receives the messages via MPI
+
+    This class is designed to be used on a system with a level of thread
+    support of MPI_THREAD_MULTIPLE.
+
+    Since multi-threading is supported, we can just send and recv messages
+    right away, no matter what thread we are on.
+    """
+
+    def send(self, msg: dict, dest: int):
+        comm.send(msg, dest=dest)
+
+    def recv(self, source: int) -> dict:
+        return comm.recv(source=source)

--- a/oremda/messengers/mpi/implementations/thread_serial.py
+++ b/oremda/messengers/mpi/implementations/thread_serial.py
@@ -1,0 +1,140 @@
+from collections import deque
+import threading
+import time
+
+from mpi4py import MPI
+
+from oremda.utils.concurrency import ThreadPoolSingleton
+from oremda.utils.singleton import Singleton
+
+comm = MPI.COMM_WORLD
+
+# The amount of time the loop sleeps each iteration, in seconds
+LOOP_INTERVAL = 0.5
+
+# The buffer size of RECV. This is unfortunately required for this messenger.
+RECV_BUFFER_SIZE = 1 << 20
+
+
+class MPIThreadSerialImplementation(Singleton):
+    """This class is designed to issue all MPI communications in one thread
+
+    This is designed to be used on a system with a level of thread support
+    of MPI_THREAD_SERIALIZED.
+
+    The underlying implementation performs the actual MPI calls on a single
+    thread that is in an infinite loop. The send() and recv() functions
+    internally wait for this thread to complete before returning.
+    """
+
+    def __init__(self):
+        self._send_queue = deque()
+        self._recv_queue = deque()
+        self._futures = []
+        self._futures_lock = threading.Lock()
+
+        # Since __init__ should only be called, once, and it should only
+        # be called if this is the implementation we are going to use,
+        # go ahead and start the loop.
+        self._loop_future = ThreadPoolSingleton().submit(self._loop_forever)
+
+    def send(self, msg: dict, dest: int):
+        future = MPIFuture()
+        self._send_queue.append((future, msg, dest))
+        future.result()
+
+    def recv(self, source: int) -> dict:
+        future = MPIFuture()
+        self._recv_queue.append((future, source))
+        return future.result()  # type: ignore
+
+    def _loop_forever(self):
+        while threading.main_thread().is_alive():
+            try:
+                time.sleep(LOOP_INTERVAL)
+                self._send_messages()
+                self._recv_messages()
+                self._test_futures()
+            except Exception as e:
+                print("_loop_forever caught an exception:", e)
+                raise
+
+    def _send_messages(self):
+        while self._send_queue:
+            try:
+                future, msg, dest = self._send_queue.popleft()
+            except IndexError:
+                # The list was emptied by another thread...
+                return
+
+            future.request = comm.isend(msg, dest=dest)
+
+            with self._futures_lock:
+                self._futures.append(future)
+
+    def _recv_messages(self):
+        while self._recv_queue:
+            try:
+                future, source = self._recv_queue.popleft()
+            except IndexError:
+                # The list was emptied by another thread...
+                return
+
+            buf = bytearray(RECV_BUFFER_SIZE)
+            future.request = comm.irecv(buf, source=source)
+
+            with self._futures_lock:
+                self._futures.append(future)
+
+    def _test_futures(self):
+        with self._futures_lock:
+            # These will notify if they are finished...
+            self._futures = [x for x in self._futures if not x.test()]
+
+
+class MPIFuture:
+    def __init__(self, request=None):
+        self.lock = threading.RLock()
+        self.cv = threading.Condition(self.lock)
+        self.request = request
+        self._result = None
+        self._complete = False
+
+    def result(self):
+        with self.lock:
+            # Wait until we are signaled that it is complete...
+            self.cv.wait_for(self.is_complete)
+            return self._result
+
+    def is_complete(self):
+        with self.lock:
+            return self._complete
+
+    def test(self):
+        with self.lock:
+            if self._complete:
+                return True
+
+            if self.request is None:
+                return False
+
+            complete, result = self.request.test()
+
+            if not complete:
+                return False
+
+            self._result = result
+            self._complete = complete
+            self.cv.notify_all()
+
+        return True
+
+    @property
+    def request(self):
+        with self.lock:
+            return self._request
+
+    @request.setter
+    def request(self, v):
+        with self.lock:
+            self._request = v

--- a/oremda/messengers/mpi/implementations/thread_serial.py
+++ b/oremda/messengers/mpi/implementations/thread_serial.py
@@ -118,7 +118,15 @@ class MPIFuture:
             if self.request is None:
                 return False
 
-            complete, result = self.request.test()
+            # Must test multiple times using a timeout, or else
+            # we will sometimes miss receives.
+            # FIXME: why???
+            complete = False
+            result = None
+            timeout = 0.001
+            start = time.time()
+            while time.time() < start + timeout and not complete:
+                complete, result = self.request.test()
 
             if not complete:
                 return False

--- a/oremda/messengers/mpi/messenger.py
+++ b/oremda/messengers/mpi/messenger.py
@@ -1,17 +1,11 @@
-from typing import Any
-from mpi4py import MPI
 from pydantic import validate_arguments
-from threading import Lock
-import time
 
 from oremda.constants import DEFAULT_PLASMA_SOCKET_PATH
 from oremda.messengers.base import BaseMessenger
 from oremda.plasma_client import PlasmaArray, PlasmaClient
 from oremda.typing import Message, Port
 
-comm = MPI.COMM_WORLD
-rank = comm.Get_rank()
-comm_lock = Lock()
+from .implementations import MPIMessengerImplementation
 
 
 class MPIMessenger(BaseMessenger):
@@ -24,6 +18,7 @@ class MPIMessenger(BaseMessenger):
 
     def __init__(self):
         self.plasma_client = PlasmaClient(DEFAULT_PLASMA_SOCKET_PATH)
+        self.impl = MPIMessengerImplementation()
 
     @property
     def type(self) -> str:
@@ -32,38 +27,11 @@ class MPIMessenger(BaseMessenger):
     @validate_arguments
     def send(self, msg: Message, dest: int):
         serialized_msg = self.detach_data(dict(msg))
-        with comm_lock:
-            req = comm.isend(serialized_msg, dest=dest)
-
-        while True:
-            time.sleep(1)
-            with comm_lock:
-                output = req.test()
-                if output[0]:
-                    return
+        self.impl.send(serialized_msg, dest=dest)
 
     @validate_arguments
     def recv(self, source: int) -> Message:
-        with comm_lock:
-            # recv can probe the needed buffer size beforehand and allocate
-            # it automatically. But irecv needs a big enough buffer size
-            # without probing, unfortunately. So we have to allocate a big
-            # enough buffer every time. Let's do 1 MB for now.
-            req = comm.irecv(bytearray(1 << 20), source=source)
-
-        while True:
-            time.sleep(1)
-            with comm_lock:
-                try:
-                    output = req.test()
-                except Exception as e:
-                    print(f"Caught exception on {rank=} from {source=}", e)
-                    print(f"{comm.probe(source=source)=}")
-                    raise
-                if output[0]:
-                    serialized_msg: Any = output[1]
-                    break
-
+        serialized_msg = self.impl.recv(source=source)
         msg = self.join_data(serialized_msg)
         return Message(**msg)
 

--- a/oremda/utils/mpi.py
+++ b/oremda/utils/mpi.py
@@ -3,15 +3,39 @@ try:
 except ImportError:
     import socket
 
+    comm = None
     rank = 0
     world_size = 1
     host_name = socket.gethostname()
+    query_thread = -1
 else:
     comm = MPI.COMM_WORLD
     rank = comm.Get_rank()
     world_size = comm.Get_size()
     host_name = MPI.Get_processor_name()
+    query_thread = MPI.Query_thread()
 
+mpi_comm = comm
 mpi_rank = rank
 mpi_world_size = world_size
 mpi_host_name = host_name
+
+
+def query_thread_to_string(query_thread):
+    if query_thread == -1:
+        return
+
+    options = {
+        MPI.THREAD_SINGLE: "MPI_THREAD_SINGLE",
+        MPI.THREAD_FUNNELED: "MPI_THREAD_FUNNELED",
+        MPI.THREAD_SERIALIZED: "MPI_THREAD_SERIALIZED",
+        MPI.THREAD_MULTIPLE: "MPI_THREAD_MULTIPLE",
+    }
+
+    if query_thread not in options:
+        raise Exception(f"Unknown level of thread support: {query_thread}")
+
+    return options[query_thread]
+
+
+mpi_thread_support = query_thread_to_string(query_thread)


### PR DESCRIPTION
This splits up the MPI messenger code into two MPI messenger
implementations, where the one used depends on the level of thread support
on the MPI system.

For systems with a level of thread support of MPI_THREAD_MULTIPLE, the 
implementation is simple and just calls `send()` and `recv()`, since we
do not need to worry about what thread is making the MPI calls.

For systems with a level of thread support of MPI_THREAD_SERIALIZED (as 
is the case on Cori at NERSC), the implementation funnels all MPI calls
to a single thread. It does this through the use of deques, locks, and 
futures. The `send()` and `recv()` calls are still blocking as they
wait for the future to finish, which allows us to avoid re-designing
other parts of the code base. This seems to be working on Cori at NERSC.
Internally, it is using MPI `isend()`, `irecv()`, and `test()` to work.

In theory, we should be able to use the MPI_THREAD_SERIALIZED class for 
MPI_THREAD_FUNNELED as well, we'd just need to make sure the main thread
is the one running the loop.