### PR TITLE
Clean up output queues when operator finishes

### DIFF
--- a/oremda/pipeline/operator.py
+++ b/oremda/pipeline/operator.py
@@ -53,7 +53,11 @@ class OperatorHandle:
         inputs: Dict[PortKey, Port],
         output_queue: str,
     ) -> Dict[PortKey, Port]:
-        return self.execute_func(inputs, output_queue)
+        try:
+            return self.execute_func(inputs, output_queue)
+        finally:
+            # Clean up the output queue
+            self.messenger.unlink(output_queue)
 
     @property
     def execute_func(self):


### PR DESCRIPTION
There was previously no cleanup code for output queues, which have names
based upon pipeline and node ids, and thus are different every time. This
would result in lots of message queues that did not get cleaned up.

Clean up the output queues when the operator handle finishes.