### PR TITLE
Allow multiple MPI ranks per node

### DIFF
--- a/examples/mpi/local_run.sh
+++ b/examples/mpi/local_run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+export PYTHONUNBUFFERED=1
+
+export OREMDA_DATA_DIR=$HOME/data/oremda
+export OREMDA_CONTAINER_TYPE=singularity
+export OREMDA_SIF_DIR=images
+export OREMDA_OPERATOR_CONFIG_FILE="operator_config.json"
+
+mpirun -np 8 oremda run pipeline.json

--- a/oremda/cli/run.py
+++ b/oremda/cli/run.py
@@ -51,7 +51,13 @@ def main(pipeline_json: click.File):
     sif_dir = os.environ.get("OREMDA_SIF_DIR", "/images")
     plasma_memory = int(os.environ.get("OREMDA_PLASMA_MEMORY", 50_000_000))
     operator_config_file = os.environ.get("OREMDA_OPERATOR_CONFIG_FILE")
-    plasma_socket_path = f"{oremda_var_dir}/plasma.sock"
+
+    if mpi_rank == 0:
+        plasma_sock = "plasma.sock"
+    else:
+        plasma_sock = f"plasma_{mpi_rank}.sock"
+
+    plasma_socket_path = f"{oremda_var_dir}/{plasma_sock}"
 
     plasma_kwargs = {
         "memory": plasma_memory,

--- a/oremda/clients/base/client.py
+++ b/oremda/clients/base/client.py
@@ -1,8 +1,11 @@
 from abc import ABC, abstractmethod
+from typing import Any, List
+
 from oremda.clients.base.container import ContainerBase
 from oremda.clients.base.image import ImageBase
+from oremda.constants import OREMDA_MPI_RANK_ENV_VAR
 from oremda.typing import ContainerType
-from typing import Any, List
+from oremda.utils.mpi import mpi_rank
 
 
 class ClientBase(ABC):
@@ -27,3 +30,9 @@ class ClientBase(ABC):
     @abstractmethod
     def images(self, organization: str = None) -> List[ImageBase]:
         pass
+
+    def add_mpi_environment_variables(self, kwargs):
+        if "environment" not in kwargs:
+            kwargs["environment"] = {}
+
+        kwargs["environment"][OREMDA_MPI_RANK_ENV_VAR] = mpi_rank

--- a/oremda/clients/docker/client.py
+++ b/oremda/clients/docker/client.py
@@ -30,9 +30,13 @@ class DockerClient(ClientBase):
             return None
 
     def run(self, *args, **kwargs):
-        # Always run in detached mode
         kwargs = kwargs.copy()
+
+        # Always run in detached mode
         kwargs["detach"] = True
+
+        # Add mpi environment variables
+        self.add_mpi_environment_variables(kwargs)
 
         container = self.client.containers.run(*args, **kwargs)
         return DockerContainer(container)

--- a/oremda/clients/singularity/client.py
+++ b/oremda/clients/singularity/client.py
@@ -40,6 +40,11 @@ class SingularityClient(ClientBase):
 
     @with_resolved_path
     def run(self, path, *args, **kwargs):
+        kwargs = kwargs.copy()
+
+        # Add mpi environment variables
+        self.add_mpi_environment_variables(kwargs)
+
         kwargs = self._docker_kwargs_to_singularity(kwargs)
 
         name = Path(path).stem
@@ -71,6 +76,10 @@ class SingularityClient(ClientBase):
 
         if "working_dir" in kwargs:
             options += ["--pwd", kwargs["working_dir"]]
+
+        if "environment" in kwargs:
+            for k, v in kwargs["environment"].items():
+                options += ["--env", f"{k}={v}"]
 
         ret["options"] = options
         return ret

--- a/oremda/constants.py
+++ b/oremda/constants.py
@@ -1,5 +1,12 @@
+from oremda.utils.mpi import OREMDA_MPI_RANK_ENV_VAR, mpi_rank  # noqa: F401
+
+if mpi_rank == 0:
+    _plasma_sock = "plasma.sock"
+else:
+    _plasma_sock = f"plasma_{mpi_rank}.sock"
+
 DEFAULT_OREMDA_VAR_DIR = "/tmp"
-DEFAULT_PLASMA_SOCKET_PATH = f"{DEFAULT_OREMDA_VAR_DIR}/plasma.sock"
+DEFAULT_PLASMA_SOCKET_PATH = f"{DEFAULT_OREMDA_VAR_DIR}/{_plasma_sock}"
 DEFAULT_DATA_DIR = "/data"
 OREMDA_DOCKER_ORG = "oremda"
 OREMDA_IMAGE_LABEL_NAME = "oremda.name"

--- a/oremda/event_loops/mpi/non_root_event_loop.py
+++ b/oremda/event_loops/mpi/non_root_event_loop.py
@@ -11,7 +11,11 @@ class MPINonRootEventLoop(MPIEventLoop):
     """Forward messages between the messages queue and MPI nodes"""
 
     async def loop(self, operator_queue):
+        # Use a queue with a rank in order to avoid queue name clashes with
+        # rank 0, in case we are running on the same node as rank 0.
+        operator_queue_with_rank = f"{operator_queue}_{mpi_rank}"
         while True:
+            print(f"{mpi_rank=} Sending ready message for: {operator_queue=}")
             # First, send a message indicating we are ready for input
             ready_msg = MPINodeReadyMessage(
                 **{
@@ -25,23 +29,35 @@ class MPINonRootEventLoop(MPIEventLoop):
             msg = await self.mpi_recv(0)
             print(f"MPI message received on {mpi_rank=}, {msg=}")
 
-            # Forward to the operator
-            print(f"Sending {msg} to {operator_queue}")
-            await self.mqp_send(msg, operator_queue)
-
-            print(f"MQP message sent to: {operator_queue=}")
-
-            # If it was a terminate task, finish this node as well
             task_message = Message(**msg.dict())
             if task_message.type == MessageType.Terminate:
+                # If it was a terminate task, send it and finish this node
+                print(f"{mpi_rank=} sending terminate task...")
+                await self.mqp_send(msg, operator_queue_with_rank)
                 print(f"{mpi_rank=} Terminating...")
+                # Clean up the operator queue with rank...
+                self.mqp_messenger.unlink(operator_queue_with_rank)
                 break
 
-            # It must have been an OperateTaskMessage. Receive the output.
+            if task_message.type != MessageType.Operate:
+                raise NotImplementedError(task_message.type)
+
+            # Add the MPI rank to the output queue to ensure we don't
+            # get a name clash with rank 0.
             operate_message = OperateTaskMessage(**msg.dict())
-            output_queue = operate_message.output_queue
-            result = await self.mqp_recv(output_queue)
+            operate_message.output_queue += f"_{mpi_rank}"
+
+            # Forward to the operator
+            print(f"Sending {operate_message} to {operator_queue_with_rank}")
+            await self.mqp_send(operate_message, operator_queue_with_rank)
+
+            print(f"MQP message sent to: {operator_queue_with_rank=}")
+
+            result = await self.mqp_recv(operate_message.output_queue)
             print(f"MQP output received: {result=}")
+
+            # Clean up the output queue
+            self.mqp_messenger.unlink(operate_message.output_queue)
 
             # Forward the result back to the main node
             await self.mpi_send(result, 0)

--- a/oremda/event_loops/mpi/root_event_loop.py
+++ b/oremda/event_loops/mpi/root_event_loop.py
@@ -13,9 +13,12 @@ class MPIRootEventLoop(MPIEventLoop):
     async def loop(self, rank):
         while True:
             # Wait until the node indicates it is ready
+            print(f"Waiting for {rank=} to be ready...")
             msg = await self.mpi_recv(rank)
+            print(f"Received message from {rank=}!")
             ready_msg = MPINodeReadyMessage(**msg.dict())
             queue = ready_msg.queue
+            print(f"{rank=} is ready! queue is {queue}. Waiting for input...")
 
             # Wait until a task becomes available for the node
             msg = await self.mqp_recv(queue)

--- a/oremda/operator.py
+++ b/oremda/operator.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from functools import wraps
-from typing import Any, Callable, Dict, Optional, Union
 from io import StringIO
 import traceback
+from typing import Any, Callable, Dict, Optional, Union
 
 from oremda import PlasmaClient
 from oremda.constants import DEFAULT_PLASMA_SOCKET_PATH
@@ -19,6 +19,7 @@ from oremda.typing import (
     MessageType,
     DataArray,
 )
+from oremda.utils.mpi import mpi_rank
 
 
 class Operator(ABC):
@@ -34,7 +35,10 @@ class Operator(ABC):
 
     @property
     def input_queue(self) -> str:
-        return f"/{self.name}"
+        input_queue = self.name
+        if mpi_rank != 0:
+            input_queue += f"_{mpi_rank}"
+        return input_queue
 
     def start(self):
         while True:

--- a/oremda/pipeline/engine/context.py
+++ b/oremda/pipeline/engine/context.py
@@ -11,6 +11,7 @@ from oremda.clients.base import ClientBase as ContainerClient
 from oremda.plasma_client import PlasmaClient
 from oremda.registry import Registry
 from oremda.constants import DEFAULT_OREMDA_VAR_DIR
+from oremda.utils.mpi import mpi_rank
 from oremda.utils.plasma import start_plasma_store
 from oremda.typing import ContainerType
 from oremda.pipeline.engine.config import settings
@@ -47,7 +48,13 @@ class GlobalContext(BaseModel):
 def pipeline_context():
     OREMDA_VAR_DIR = settings.OREMDA_VAR_DIR
     OREMDA_DATA_DIR = settings.OREMDA_DATA_DIR
-    PLASMA_SOCKET = f"{OREMDA_VAR_DIR}/plasma.sock"
+
+    if mpi_rank == 0:
+        _plasma_sock = "plasma.sock"
+    else:
+        _plasma_sock = f"plasma_{mpi_rank}.sock"
+
+    PLASMA_SOCKET = f"{OREMDA_VAR_DIR}/{_plasma_sock}"
 
     plasma_kwargs = {"memory": 50_000_000, "socket_path": PLASMA_SOCKET}
 

--- a/oremda/utils/mpi.py
+++ b/oremda/utils/mpi.py
@@ -1,3 +1,8 @@
+import os
+
+# Constants
+OREMDA_MPI_RANK_ENV_VAR = "OREMDA_MPI_RANK"
+
 try:
     from mpi4py import MPI
 except ImportError:
@@ -19,6 +24,10 @@ mpi_comm = comm
 mpi_rank = rank
 mpi_world_size = world_size
 mpi_host_name = host_name
+
+if env_rank := os.environ.get(OREMDA_MPI_RANK_ENV_VAR):
+    # Override the MPI rank with what was provided in the environment
+    mpi_rank = int(env_rank)
 
 
 def query_thread_to_string(query_thread):


### PR DESCRIPTION
Multiple MPI ranks per node was previously not possible due to clashes
in plasma store and message queue names between ranks.

With this commit, all ranks other than rank 0 now append their MPI
rank to their plasma store and message queue names, in order to prevent
name clashes. The `MPINonRootEventLoop` now also modifies the output
queue on an operate message temporarily, to avoid clashes with rank 0.

This commit also allows operators to see their MPI rank via the
`oremda.utils.mpi.mpi_rank` variable, as long as the environment
variable "OREMDA_MPI_RANK" was set. This environment variable is
being set in both docker containers and singularity containers, so
all operators should now be able to access their MPI rank, even though
they are unable to communicate through MPI. Seeing their MPI rank allows
them to append it to their plasma store and message queue names as well.